### PR TITLE
Add official dbt documentation links to all guides

### DIFF
--- a/dbt/dbt_expectations_comprehensive_summary.html
+++ b/dbt/dbt_expectations_comprehensive_summary.html
@@ -1252,6 +1252,16 @@ Data Completeness Analysis:<br>
             </div>
         </section>
 
+        <section style="margin-top: 40px; padding: 20px; background-color: #f8f9fa; border-radius: 8px;">
+            <h2>📚 Official dbt Documentation</h2>
+            <p>For comprehensive information about dbt testing and data quality, refer to the official documentation:</p>
+            <ul>
+                <li><strong><a href="https://docs.getdbt.com/docs/build/data-tests" target="_blank">Data tests</a></strong> - Official guide to dbt testing framework and best practices</li>
+                <li><strong><a href="https://github.com/metaplane/dbt-expectations" target="_blank">dbt-expectations package</a></strong> - Official repository for the dbt-expectations package</li>
+            </ul>
+            <p><em>These resources provide the authoritative source for dbt testing capabilities and are regularly updated.</em></p>
+        </section>
+
         <footer style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #ddd; text-align: center; color: #666;">
             <p>This comprehensive summary covers all major tests in the dbt-expectations package (v0.10.9). 
             For the most up-to-date information, refer to the 

--- a/dbt/dbt_incremental_strategies_guide.html
+++ b/dbt/dbt_incremental_strategies_guide.html
@@ -1531,6 +1531,18 @@ where id is not null  -- Prevent NULL unique_key issues
 
                 <p>Remember: <span class="highlight">Choose based on your data patterns, not just performance</span>. The wrong strategy can cause data corruption, while the right strategy makes your pipelines both fast and reliable.</p>
             </div>
+
+            <div class="section">
+                <h2>📚 Official dbt Documentation</h2>
+                <div class="recommendation-box">
+                    <p>For the most up-to-date information and comprehensive details, refer to the official dbt documentation:</p>
+                    <ul>
+                        <li><strong><a href="https://docs.getdbt.com/docs/build/incremental-models" target="_blank">Incremental models</a></strong> - Official guide to dbt incremental materialization</li>
+                        <li><strong><a href="https://docs.getdbt.com/best-practices/materializations/1-guide-overview" target="_blank">Materializations best practices</a></strong> - Guide to choosing and implementing dbt materializations</li>
+                    </ul>
+                    <p><em>These resources provide the authoritative source for dbt incremental strategies and are regularly updated by the dbt Labs team.</em></p>
+                </div>
+            </div>
         </div>
     </div>
 </body>

--- a/dbt/dbt_merge_complete_guide.html
+++ b/dbt/dbt_merge_complete_guide.html
@@ -699,6 +699,18 @@ where is_active = true
                 
                 <p>Remember: <span class="highlight">Start simple, measure performance, and evolve based on actual needs</span> rather than theoretical requirements.</p>
             </div>
+
+            <div class="section">
+                <h2>📚 Official dbt Documentation</h2>
+                <div class="highlight">
+                    <p>For the most up-to-date information and comprehensive details, refer to the official dbt documentation:</p>
+                    <ul>
+                        <li><strong><a href="https://docs.getdbt.com/docs/build/incremental-models" target="_blank">Incremental models</a></strong> - Official guide to dbt incremental materialization and merge strategies</li>
+                        <li><strong><a href="https://docs.getdbt.com/best-practices/materializations/1-guide-overview" target="_blank">Materializations best practices</a></strong> - Guide to choosing and implementing dbt materializations</li>
+                    </ul>
+                    <p><em>These resources provide the authoritative source for dbt merge operations and are regularly updated by the dbt Labs team.</em></p>
+                </div>
+            </div>
         </div>
     </div>
 </body>

--- a/dbt/dbt_modeling_guidelines.html
+++ b/dbt/dbt_modeling_guidelines.html
@@ -627,6 +627,17 @@ order by 1 desc, 5 desc
             <li>Leverage macros for reusable logic</li>
             <li>Keep SQL readable and well-commented</li>
         </ul>
+
+        <h2>📚 Official dbt Documentation</h2>
+        <div class="highlight">
+            <p>For the most up-to-date information and comprehensive details, refer to the official dbt documentation:</p>
+            <ul>
+                <li><strong><a href="https://docs.getdbt.com/best-practices/how-we-structure/1-guide-overview" target="_blank">How we structure our dbt projects</a></strong> - Official guide to dbt project organization and layering</li>
+                <li><strong><a href="https://docs.getdbt.com/docs/build/models" target="_blank">About dbt models</a></strong> - Comprehensive documentation on dbt models and their structure</li>
+                <li><strong><a href="https://docs.getdbt.com/best-practices/materializations/1-guide-overview" target="_blank">Materializations best practices</a></strong> - Guide to choosing and implementing dbt materializations</li>
+            </ul>
+            <p><em>These resources provide the authoritative source for dbt best practices and are regularly updated by the dbt Labs team.</em></p>
+        </div>
     </div>
 </body>
 </html>

--- a/dbt/dbt_utils_macros_comprehensive_summary.html
+++ b/dbt/dbt_utils_macros_comprehensive_summary.html
@@ -1424,6 +1424,16 @@ Generated columns are database-safe identifiers for dynamic SQL generation
             </div>
         </section>
 
+        <section style="margin-top: 40px; padding: 20px; background-color: #f8f9fa; border-radius: 8px;">
+            <h2>📚 Official dbt Documentation</h2>
+            <p>For comprehensive information about dbt macros and utilities, refer to the official documentation:</p>
+            <ul>
+                <li><strong><a href="https://docs.getdbt.com/docs/build/jinja-macros" target="_blank">Jinja macros</a></strong> - Official guide to creating and using dbt macros</li>
+                <li><strong><a href="https://hub.getdbt.com/dbt-labs/dbt_utils/latest/" target="_blank">dbt_utils package</a></strong> - Official dbt_utils package documentation and reference</li>
+            </ul>
+            <p><em>These resources provide the authoritative source for dbt macro capabilities and are regularly updated.</em></p>
+        </section>
+
         <footer style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #ddd; text-align: center; color: #666;">
             <p>This comprehensive summary covers all 43 macros in the dbt_utils package. For the most up-to-date information, 
             refer to the <a href="https://hub.getdbt.com/dbt-labs/dbt_utils/latest/">official dbt_utils documentation</a>.</p>


### PR DESCRIPTION
## Summary
- Added verified official documentation links to all dbt HTML files
- Enhanced content accessibility with authoritative dbt references
- Improved user experience with direct links to relevant official sources

## Changes Made
- **dbt_modeling_guidelines.html**: Added links to project structure, models, and materialization docs
- **dbt_incremental_strategies_guide.html**: Added links to incremental models and materialization practices
- **dbt_expectations_comprehensive_summary.html**: Added links to data tests and dbt-expectations package
- **dbt_utils_macros_comprehensive_summary.html**: Added links to Jinja macros and dbt_utils package
- **dbt_merge_complete_guide.html**: Added links to incremental models and materialization practices

## Quality Assurance
- All links were verified using WebFetch before inclusion
- Only existing, accessible URLs were added
- Consistent formatting and styling across all documents
- Links open in new tabs for better user experience

## Benefits
- **Authoritative Sources**: Direct access to official dbt documentation
- **Up-to-date Information**: Links to regularly maintained official docs
- **Enhanced Learning**: Easy access to comprehensive details beyond guide scope
- **Professional Standards**: Follows documentation best practices

## Test Plan
- [x] Verify all links are accessible and correct
- [x] Check consistent formatting across all files
- [x] Ensure links open in new tabs
- [ ] Test links work correctly from live GitHub Pages site

🤖 Generated with [Claude Code](https://claude.ai/code)