### PR TITLE
Fix terminal code block styling - ensure green text appears correctly

### DIFF
--- a/dbt/dbt_lambda_functions_comprehensive_guide.html
+++ b/dbt/dbt_lambda_functions_comprehensive_guide.html
@@ -102,6 +102,17 @@
             box-shadow: inset 0 0 10px rgba(0, 255, 0, 0.1);
         }
         
+        pre code {
+            background: transparent;
+            color: #00ff00;
+            padding: 0;
+            border-radius: 0;
+            font-family: inherit;
+            font-size: inherit;
+            border: none;
+            box-shadow: none;
+        }
+        
         code {
             background: #f1f5f9;
             color: #e53e3e;
@@ -109,6 +120,14 @@
             border-radius: 3px;
             font-family: 'Monaco', 'Consolas', monospace;
             font-size: 0.9em;
+        }
+        
+        pre code::selection {
+            background: rgba(0, 255, 0, 0.3);
+        }
+        
+        pre code::-moz-selection {
+            background: rgba(0, 255, 0, 0.3);
         }
         
         .highlight {


### PR DESCRIPTION
## Problem Fixed
The previous terminal styling update had issues where:
- Code elements inside pre blocks were still showing orange text instead of green
- White/gray backgrounds were appearing around code text
- Selection highlighting was not properly styled for the terminal theme

## Solution Applied
- **Specific CSS for pre code**: Added `pre code` selector to override inline code styling
- **Transparent background**: Removed conflicting backgrounds from code elements inside pre blocks
- **Consistent green text**: Ensured all code within pre blocks uses terminal green (#00ff00)
- **Clean appearance**: Removed padding, borders, and box-shadows that were causing the "selected" look
- **Custom selection**: Added semi-transparent green selection highlighting
- **Font inheritance**: Ensured consistent monospace font throughout code blocks

## Result
Now the code blocks will display properly with:
- ✅ Pure black background
- ✅ Bright green text (#00ff00)
- ✅ No unwanted borders or backgrounds
- ✅ Proper terminal-style selection highlighting

🤖 Generated with [Claude Code](https://claude.ai/code)