### PR TITLE
Fix Jekyll build error with Liquid syntax in code examples

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,20 @@
+# GitHub Pages Jekyll configuration
+theme: jekyll-theme-primer
+
+# Exclude code example files from Jekyll processing
+exclude:
+  - "dbt/code_examples/**/*.sql"
+  - "dbt/code_examples/**/*.yml" 
+  - "dbt/code_examples/**/*.yaml"
+  - "dbt/code_examples/**/*.py"
+
+# Markdown processor
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+
+# Enable plugins
+plugins:
+  - jekyll-github-metadata
+  - jekyll-seo-tag

--- a/dbt/code_examples/dbt_performance_optimization_guide/README.md
+++ b/dbt/code_examples/dbt_performance_optimization_guide/README.md
@@ -123,7 +123,7 @@ CREATE TABLE IF NOT EXISTS analytics.dbt_performance_log (
 **Cost-Optimized Development Model:**
 ```sql
 {{ config(
-    materialized={% if target.name == 'dev' %}'view'{% else %}'table'{% endif %},
+    materialized={% raw %}{% if target.name == 'dev' %}{% endraw %}'view'{% raw %}{% else %}{% endraw %}'table'{% raw %}{% endif %}{% endraw %},
     pre_hook="{{ enforce_dev_limits() }}"
 ) }}
 ```


### PR DESCRIPTION
## Summary
• Fix Jekyll build failure caused by Liquid templating syntax in code examples
• Escape problematic Liquid syntax in README.md files using {% raw %} tags  
• Add _config.yml to exclude SQL/YAML/Python files from Jekyll processing
• Prevent Jekyll from parsing dbt code examples containing {% %} syntax

## Test plan
- [ ] Verify GitHub Pages build passes without Liquid syntax errors
- [ ] Check that code examples still display correctly on the website
- [ ] Confirm _config.yml properly excludes code example files from processing
- [ ] Test that the semantic layer guide displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)