### PR TITLE
Fix Jekyll Liquid syntax error with proper raw tag placement

### DIFF
--- a/dbt/code_examples/dbt_performance_optimization_guide/README.md
+++ b/dbt/code_examples/dbt_performance_optimization_guide/README.md
@@ -121,12 +121,14 @@ CREATE TABLE IF NOT EXISTS analytics.dbt_performance_log (
 ```
 
 **Cost-Optimized Development Model:**
+{% raw %}
 ```sql
 {{ config(
-    materialized={% raw %}{% if target.name == 'dev' %}{% endraw %}'view'{% raw %}{% else %}{% endraw %}'table'{% raw %}{% endif %}{% endraw %},
+    materialized={% if target.name == 'dev' %}'view'{% else %}'table'{% endif %},
     pre_hook="{{ enforce_dev_limits() }}"
 ) }}
 ```
+{% endraw %}
 
 ## 📊 Performance Metrics
 


### PR DESCRIPTION
## Summary
• Fix remaining Jekyll build failure from previous Liquid syntax fix
• Properly wrap entire code block in {% raw %} tags instead of inline escaping
• Prevent Jekyll from parsing any dbt Jinja2 syntax in README code examples
• Resolve GitHub Pages build error that was still occurring after initial fix

## Test plan
- [ ] Verify GitHub Pages build passes completely without any Liquid syntax errors
- [ ] Check that code examples display correctly in the documentation
- [ ] Confirm the semantic layer guide is properly deployed

🤖 Generated with [Claude Code](https://claude.ai/code)